### PR TITLE
Fixing it for Neuroconductor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ichseg
 Type: Package
 Title: Intracerebral Hemorrhage Segmentation of X-Ray Computed Tomography (CT)
     Images
-Version: 0.20.4
+Version: 0.20.5
 Authors@R: c(person(given = "John", family = "Muschelli", email = "muschellij2@gmail.com",
   role = c("aut", "cre")))
 Description: Performs preprocessing on computed tomography (CT) scans, including
@@ -21,7 +21,8 @@ Imports:
     magic,
     randomForest,
     shiny,
-    utils
+    utils,
+    rmarkdown
 Suggests:
     dcmtk,
     tractor.base,

--- a/R/deepbleed.R
+++ b/R/deepbleed.R
@@ -9,7 +9,7 @@
 #' @rdname deepbleed
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' destfile = file.path(tempdir(), "01.tar.xz")
 #' dl = download.file(
 #'   "https://archive.data.jhu.edu/api/access/datafile/1311?gbrecs=true",

--- a/man/ct_dcm2nii.Rd
+++ b/man/ct_dcm2nii.Rd
@@ -31,6 +31,9 @@ dimensions}
 \item{ignore_roi_if_multiple}{additional argument to pass to
 [dcm2niir::check_dcm2nii()] to remove ROI overlays if present}
 
+\item{fail_on_error}{if the exit code from [dcm2niir::dcm2nii] is not
+`0` and `fail_on_error = TRUE`, function will error out}
+
 \item{uncorrected}{passed to [dcm2niir::check_dcm2nii()] to grab the
 "uncorrected" scan.  Do not use unless you understand the `dcm2niix`
 correction process.}

--- a/man/deepbleed.Rd
+++ b/man/deepbleed.Rd
@@ -45,7 +45,7 @@ DeepBleed Model
 \url{https://github.com/muschellij2/deepbleed}
 }
 \examples{
-\donttest{
+\dontrun{
 destfile = file.path(tempdir(), "01.tar.xz")
 dl = download.file(
   "https://archive.data.jhu.edu/api/access/datafile/1311?gbrecs=true",


### PR DESCRIPTION
Making sure `\dontest` are not run as the `R CMD check` behavior changed. Details [here](https://cran.r-project.org/doc/manuals/r-devel/NEWS.html), look for `UTILITIES` section.